### PR TITLE
Wip/build actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-24.04, ubuntu-24.04-arm64]
         compiler: [clang, gcc]
         protobuf_lib: [protobuf-c, protobuf-cpp]
         valgrind: [valgrind,no-valgrind]
@@ -73,7 +73,7 @@ jobs:
         COMPILER: ${{ matrix.compiler }}
         VALGRIND: ${{ matrix.valgrind }}
     - name: Build and run tests
-      run: make $FLAGS
+      run: make $FLAGS build_shared
       env:
         FLAGS: ${{ format('{0} {1} {2}', steps.make_flags.outputs.proto_flags, steps.make_flags.outputs.compiler_flags, steps.make_flags.outputs.debug_flags) }}
   build_macos:
@@ -82,7 +82,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Build and run tests
-      run: make
+      run: make build_shared
   build_windows_msvc:
     runs-on: windows-latest
     strategy:
@@ -97,7 +97,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Build and run tests
-      run: nmake /F Makefile.msvc
+      run: nmake /F Makefile.msvc build_shared
   build_windows_msys2:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,13 +100,13 @@ jobs:
         id: names
         shell: bash
         run: |
-          echo "binary=windows-${{ matrix.arch }}-pg_query.dll" >> $GITHUB_OUTPUT
-          echo "zipfile=windows-${{ matrix.arch }}-pg_query.dll.zip" >> $GITHUB_OUTPUT
+          echo "binary=windows-${{ matrix.arch }}-libpg_query.dll" >> $GITHUB_OUTPUT
+          echo "zipfile=windows-${{ matrix.arch }}-libpg_query.dll.zip" >> $GITHUB_OUTPUT
 
       - name: Rename and zip binary
         shell: bash
         run: |
-          cp pg_query.dll ${{ steps.names.outputs.binary }}
+          cp libpg_query.dll ${{ steps.names.outputs.binary }}
           7z a ${{ steps.names.outputs.zipfile }} ${{ steps.names.outputs.binary }}
 
       - name: Upload to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: x64
+          - os: ubuntu-24.04-arm64
+            arch: arm64
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Build shared library
+        run: make build_shared
+
+      - name: Determine file names
+        id: names
+        run: |
+          echo "binary=linux-${{ matrix.arch }}-libpg_query.so" >> $GITHUB_OUTPUT
+          echo "zipfile=linux-${{ matrix.arch }}-libpg_query.so.zip" >> $GITHUB_OUTPUT
+
+      - name: Rename and zip binary
+        run: |
+          cp libpg_query.so ${{ steps.names.outputs.binary }}
+          zip ${{ steps.names.outputs.zipfile }} ${{ steps.names.outputs.binary }}
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.names.outputs.zipfile }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Build shared library
+        run: make build_shared
+
+      - name: Determine file names
+        id: names
+        run: |
+          echo "binary=osx-${{ matrix.arch }}-libpg_query.dylib" >> $GITHUB_OUTPUT
+          echo "zipfile=osx-${{ matrix.arch }}-libpg_query.dylib.zip" >> $GITHUB_OUTPUT
+
+      - name: Rename and zip binary
+        run: |
+          cp libpg_query.dylib ${{ steps.names.outputs.binary }}
+          zip ${{ steps.names.outputs.zipfile }} ${{ steps.names.outputs.binary }}
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.names.outputs.zipfile }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, x86]
+    steps:
+      - name: Configure MSVC developer console
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Build shared library
+        run: nmake /F Makefile.msvc build_shared
+
+      - name: Determine file names
+        id: names
+        shell: bash
+        run: |
+          echo "binary=windows-${{ matrix.arch }}-pg_query.dll" >> $GITHUB_OUTPUT
+          echo "zipfile=windows-${{ matrix.arch }}-pg_query.dll.zip" >> $GITHUB_OUTPUT
+
+      - name: Rename and zip binary
+        shell: bash
+        run: |
+          cp pg_query.dll ${{ steps.names.outputs.binary }}
+          7z a ${{ steps.names.outputs.zipfile }} ${{ steps.names.outputs.binary }}
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.names.outputs.zipfile }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - '*'
   release:
     types: [created]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-24.04
             arch: x64
-          - os: ubuntu-24.04-arm64
+          - os: ubuntu-24.04-arm
             arch: arm64
     steps:
       - name: Check out code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ steps.names.outputs.zipfile }}
+          tag_name: ${{ github.event.release.tag_name || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -73,6 +74,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ steps.names.outputs.zipfile }}
+          tag_name: ${{ github.event.release.tag_name || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -111,5 +113,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ steps.names.outputs.zipfile }}
+          tag_name: ${{ github.event.release.tag_name || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build-linux:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,8 @@ jobs:
         id: names
         shell: bash
         run: |
-          echo "binary=windows-${{ matrix.arch }}-libpg_query.dll" >> $GITHUB_OUTPUT
-          echo "zipfile=windows-${{ matrix.arch }}-libpg_query.dll.zip" >> $GITHUB_OUTPUT
+          echo "binary=win-${{ matrix.arch }}-libpg_query.dll" >> $GITHUB_OUTPUT
+          echo "zipfile=win-${{ matrix.arch }}-libpg_query.dll.zip" >> $GITHUB_OUTPUT
 
       - name: Rename and zip binary
         shell: bash


### PR DESCRIPTION
This pull request makes significant improvements to the CI and release workflow for the project. It expands the CI matrix to include additional architectures, updates build steps to ensure shared libraries are built, and introduces an automated release workflow for Linux, macOS, and Windows. These changes enhance platform coverage and streamline the release process.

**CI Workflow Enhancements:**

* Expanded the CI matrix to build on both `ubuntu-24.04` and `ubuntu-24.04-arm64`, increasing test coverage for different architectures. (.github/workflows/ci.yml)
* Updated build steps in CI jobs to use `make build_shared` (or equivalent for Windows), ensuring that shared libraries are built and tested across platforms. (.github/workflows/ci.yml) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL76-R76) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL85-R85) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL100-R100)

**Automated Release Workflow:**

* Added a new release workflow file `.github/workflows/release.yml` that builds shared libraries for Linux (x64, arm64), macOS (arm64), and Windows (x64, x86), packages them, and uploads them to GitHub Releases automatically on tag or release creation. (.github/workflows/release.yml)